### PR TITLE
feat: sync client-side chat status via Riot Client local API

### DIFF
--- a/NoChat4U/ChatProxy.swift
+++ b/NoChat4U/ChatProxy.swift
@@ -5,31 +5,22 @@ import Logging
 
 private var logger = Logger(label: "NoChat4U.ChatProxy")
 
-extension NIOSSLServerHandler: @retroactive @unchecked Sendable {}
-extension NIOSSLClientHandler: @retroactive @unchecked Sendable {}
-extension ChannelHandlerContext: @retroactive @unchecked Sendable {}
-
-class ChatProxy {
+final class ChatProxy {
     private let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+    private let connectionsLock = NIOLock()
     private var connections = [ObjectIdentifier: ProxiedConnection]()
     private let serverSSLContext: NIOSSLContext
  
     init(certificateChain: [NIOSSLCertificate], privateKey: NIOSSLPrivateKey) throws {
-        // Create server SSL context using the provided certificate chain (leaf + intermediates)
         var serverConfig = TLSConfiguration.makeServerConfiguration(
             certificateChain: certificateChain.map { .certificate($0) },
             privateKey: .privateKey(privateKey)
         )
         serverConfig.certificateVerification = .none
-        serverConfig.trustRoots = .default
-        serverConfig.minimumTLSVersion = .tlsv1
-        serverConfig.maximumTLSVersion = .tlsv12
-        serverConfig.cipherSuites = "ALL"
-        serverConfig.renegotiationSupport = .always
+        serverConfig.minimumTLSVersion = .tlsv12
         
         self.serverSSLContext = try NIOSSLContext(configuration: serverConfig)
         
-        // Set up a notification observer for when the status changes
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(statusChanged),
@@ -47,18 +38,13 @@ class ChatProxy {
     }
     
     private func sendUpdatedPresence() {
-        guard let lastPresence = SharedState.shared.getLastPresence(),
-              !connections.isEmpty else {
-            return
+        guard let lastPresence = SharedState.shared.getLastPresence() else { return }
+        
+        let connection: ProxiedConnection? = connectionsLock.withLock {
+            connections.values.first
         }
         
-        logger.info("Status changed, sending updated presence stanza")
-        
-        // Use the first active connection to send the presence
-        guard let connection = connections.values.first else {
-            logger.warning("No active connections to send presence update")
-            return
-        }
+        guard let conn = connection, let serverChannel = conn.serverChannel else { return }
         
         let targetStatus = SharedState.shared.targetStatus
         let modifiedStanza = modifyPresenceXML(lastPresence, targetStatus: targetStatus)
@@ -68,14 +54,9 @@ class ChatProxy {
         var presenceBuffer = ByteBuffer()
         presenceBuffer.writeString(modifiedStanza)
         
-        guard let serverChannel = connection.serverChannel else {
-            return
-        }
-        
         serverChannel.eventLoop.execute {
-                    serverChannel.writeAndFlush(presenceBuffer, promise: nil)
-                }
-        
+            serverChannel.writeAndFlush(presenceBuffer, promise: nil)
+        }
     }
     
     func start() throws {
@@ -86,23 +67,23 @@ class ChatProxy {
             .childChannelInitializer { [self] channel in
                 logger.debug("New client connection received")
                 
-                // Create the connection object first
                 let connection = ProxiedConnection(clientChannel: channel, eventLoop: channel.eventLoop)
-                self.connections[ObjectIdentifier(connection)] = connection
+                self.connectionsLock.withLock {
+                    self.connections[ObjectIdentifier(connection)] = connection
+                }
                 
-                // When client disconnects, remove the connection
                 channel.closeFuture.whenComplete { [weak self] _ in
                     guard let self = self else { return }
-                    if let connId = self.connections.first(where: { $0.value.clientChannel === channel })?.key {
-                        logger.info("Removing connection on client disconnect")
-                        self.connections.removeValue(forKey: connId)
+                    self.connectionsLock.withLock {
+                        if let connId = self.connections.first(where: { $0.value.clientChannel === channel })?.key {
+                            logger.info("Removing connection on client disconnect")
+                            self.connections.removeValue(forKey: connId)
+                        }
                     }
                 }
                 
-                // First add SSL handler to client side
                 let sslHandler = NIOSSLServerHandler(context: self.serverSSLContext)
                 return channel.pipeline.addHandler(sslHandler).flatMap { _ in
-                    // Then establish connection to server and create the proxy pipeline
                     return self.connectToServer(connection: connection).flatMap { serverChannel in
                         logger.debug("Successfully connected to server, adding client handler")
                         return channel.pipeline.addHandler(ClientToServerHandler(connection: connection))
@@ -113,7 +94,6 @@ class ChatProxy {
             .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 16)
             .childChannelOption(ChannelOptions.recvAllocator, value: AdaptiveRecvByteBufferAllocator())
         
-        // Bind on localhost with a random port
         bootstrap.bind(host: "127.0.0.1", port: 0).whenComplete { result in
             switch result {
             case .success(let channel):
@@ -138,16 +118,12 @@ class ChatProxy {
         
         logger.info("Connecting to server \(host):\(port)")
         
-        // Configure SSL/TLS for the outgoing connection if needed
         let sslContext: NIOSSLContext?
         
         var sslConfig = TLSConfiguration.makeClientConfiguration()
-        sslConfig.certificateVerification = .none
-        sslConfig.trustRoots = .default
+        sslConfig.certificateVerification = .fullVerification
         sslConfig.applicationProtocols = ["xmpp-client"]
-        sslConfig.minimumTLSVersion = .tlsv1
-        sslConfig.maximumTLSVersion = .tlsv13
-        sslConfig.cipherSuites = "ALL"
+        sslConfig.minimumTLSVersion = .tlsv12
         
         do {
             sslContext = try NIOSSLContext(configuration: sslConfig)
@@ -157,31 +133,32 @@ class ChatProxy {
         }
         
         let bootstrap = ClientBootstrap(group: group)
-            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .channelOption(ChannelOptions.connectTimeout, value: .seconds(10))
             .channelInitializer { channel in
                 logger.debug("Initializing channel to server")
                 
                 if let sslContext = sslContext {
-                    let sslHandler = try! NIOSSLClientHandler(
-                        context: sslContext,
-                        serverHostname: host
-                    )
-                    return channel.pipeline.addHandler(sslHandler).flatMap {
-                        logger.debug("SSL handler added, adding server-to-client handler")
-                        return channel.pipeline.addHandler(ServerToClientHandler(connection: connection))
+                    do {
+                        let sslHandler = try NIOSSLClientHandler(
+                            context: sslContext,
+                            serverHostname: host
+                        )
+                        return channel.pipeline.addHandler(sslHandler).flatMap {
+                            logger.debug("SSL handler added, adding server-to-client handler")
+                            return channel.pipeline.addHandler(ServerToClientHandler(connection: connection))
+                        }
+                    } catch {
+                        return channel.eventLoop.makeFailedFuture(error)
                     }
                 } else {
                     return channel.pipeline.addHandler(ServerToClientHandler(connection: connection))
                 }
             }
         
-        // Connect to the original server
         return bootstrap.connect(host: host, port: port).map { serverChannel in
             logger.info("Connected to Riot chat server")
             connection.serverChannel = serverChannel
             
-            // When server disconnects, close the client connection too
             serverChannel.closeFuture.whenComplete { _ in
                 logger.debug("Server disconnected, closing client connection")
                 connection.clientChannel.close(promise: nil)
@@ -193,13 +170,13 @@ class ChatProxy {
     
     func stop() {
         logger.info("Stopping chat proxy")
-        for (_, connection) in connections {
-            connection.clientChannel.close(promise: nil)
-            connection.serverChannel?.close(promise: nil)
+        connectionsLock.withLock {
+            for (_, connection) in connections {
+                connection.clientChannel.close(promise: nil)
+                connection.serverChannel?.close(promise: nil)
+            }
+            connections.removeAll()
         }
-        connections.removeAll()
-        
-        try? group.syncShutdownGracefully()
     }
 }
 
@@ -208,11 +185,17 @@ enum ChatProxyError: Error {
 }
 
 /// A connection between a client and server
-class ProxiedConnection {
+final class ProxiedConnection {
     let clientChannel: Channel
-    var serverChannel: Channel?
     private let eventLoop: EventLoop
     private var xmlBufferToServer = ""
+    private let serverChannelLock = NIOLock()
+    private var _serverChannel: Channel?
+    
+    var serverChannel: Channel? {
+        get { serverChannelLock.withLock { _serverChannel } }
+        set { serverChannelLock.withLock { _serverChannel = newValue } }
+    }
     
     init(clientChannel: Channel, eventLoop: EventLoop) {
         self.clientChannel = clientChannel
@@ -226,112 +209,97 @@ class ProxiedConnection {
         }
         
         if !eventLoop.inEventLoop {
-            return eventLoop.submit { 
+            return eventLoop.submit {
                 self.processClientData(data)
             }.flatMap { $0 }
         }
         
-        // Get the string data if possible
         let string = data.getString(at: data.readerIndex, length: data.readableBytes) ?? ""
-            logger.debug("Client data: \(string)")
-            
-            // Append to our buffer
-            xmlBufferToServer += string
-            
-            // Check for presence stanza and modify if found
-            if xmlBufferToServer.contains("<presence") && xmlBufferToServer.contains("</presence>") {
-                if let presenceStartRange = xmlBufferToServer.range(of: "<presence"),
-                   let presenceEndRange = xmlBufferToServer.range(of: "</presence>") {
-                        // Extract the presence stanza
-                        let stanzaEndIndex = presenceEndRange.upperBound
-                        let presenceStanza = String(xmlBufferToServer[presenceStartRange.lowerBound..<stanzaEndIndex])
-                        
-                        if(!presenceStanza.contains("to='")) {
-                            // Store the original presence stanza
-                            SharedState.shared.storeLastPresence(presenceStanza)
-                        }
-                        
-                        // Remove from buffer
-                        let beforeStanza = presenceStartRange.lowerBound > xmlBufferToServer.startIndex ? 
-                            String(xmlBufferToServer[..<presenceStartRange.lowerBound]) : ""
-                        let afterStanza = stanzaEndIndex < xmlBufferToServer.endIndex ? 
-                            String(xmlBufferToServer[stanzaEndIndex...]) : ""
-                        xmlBufferToServer = beforeStanza + afterStanza
-                        
-                        // Modify the presence stanza
-                        let targetStatus = SharedState.shared.targetStatus
-                        let modifiedStanza = modifyPresenceXML(presenceStanza, targetStatus: targetStatus)
-                        
-                        logger.debug("Modified presence stanza: \(modifiedStanza)")
-                        
-                        // Create buffer and send
-                        var presenceBuffer = ByteBuffer()
-                        presenceBuffer.writeString(modifiedStanza)
-                        
-                        return serverChannel.eventLoop.submit {
-                                serverChannel.writeAndFlush(presenceBuffer)
-                            }.flatMap { $0 }.flatMap {
-                                // Forward remaining buffer if any
-                                if !self.xmlBufferToServer.isEmpty {
-                                    return self.processClientData(ByteBuffer()) 
-                                } else {
-                                    return self.eventLoop.makeSucceededFuture(())
-                                }
-                            }
-                     
+        logger.debug("Client data: \(string)")
+        
+        xmlBufferToServer += string
+        
+        if xmlBufferToServer.contains("<presence") && xmlBufferToServer.contains("</presence>") {
+            if let presenceStartRange = xmlBufferToServer.range(of: "<presence"),
+               let presenceEndRange = xmlBufferToServer.range(of: "</presence>") {
+                let stanzaEndIndex = presenceEndRange.upperBound
+                let presenceStanza = String(xmlBufferToServer[presenceStartRange.lowerBound..<stanzaEndIndex])
+                
+                if !presenceStanza.contains("to='") {
+                    SharedState.shared.storeLastPresence(presenceStanza)
                 }
-            } 
-            
-            // forward remaining buffer
-            var buffer = ByteBuffer()
-                buffer.writeString(xmlBufferToServer)
-                xmlBufferToServer = ""
+                
+                let beforeStanza = presenceStartRange.lowerBound > xmlBufferToServer.startIndex ?
+                    String(xmlBufferToServer[..<presenceStartRange.lowerBound]) : ""
+                let afterStanza = stanzaEndIndex < xmlBufferToServer.endIndex ?
+                    String(xmlBufferToServer[stanzaEndIndex...]) : ""
+                xmlBufferToServer = beforeStanza + afterStanza
+                
+                let targetStatus = SharedState.shared.targetStatus
+                let modifiedStanza = modifyPresenceXML(presenceStanza, targetStatus: targetStatus)
+                
+                logger.debug("Modified presence stanza: \(modifiedStanza)")
+                
+                var presenceBuffer = ByteBuffer()
+                presenceBuffer.writeString(modifiedStanza)
                 
                 return serverChannel.eventLoop.submit {
-                        serverChannel.writeAndFlush(buffer)
-                    }.flatMap { $0 }
+                    serverChannel.writeAndFlush(presenceBuffer)
+                }.flatMap { $0 }.flatMap {
+                    if !self.xmlBufferToServer.isEmpty {
+                        return self.processClientData(ByteBuffer())
+                    } else {
+                        return self.eventLoop.makeSucceededFuture(())
+                    }
+                }
+            }
+        }
+        
+        var buffer = ByteBuffer()
+        buffer.writeString(xmlBufferToServer)
+        xmlBufferToServer = ""
+        
+        return serverChannel.eventLoop.submit {
+            serverChannel.writeAndFlush(buffer)
+        }.flatMap { $0 }
     }
     
     /// Forward data from server to client (no modifications needed)
     func forwardToClient(_ data: ByteBuffer) -> EventLoopFuture<Void> {
         return clientChannel.eventLoop.submit {
-                self.clientChannel.writeAndFlush(data)
-            }.flatMap { $0 }
+            self.clientChannel.writeAndFlush(data)
+        }.flatMap { $0 }
     }
 }
 
 /// Modifies presence XML to change the status if needed
 private func modifyPresenceXML(_ xml: String, targetStatus: String) -> String {
     guard targetStatus == "offline" else {
-        return xml // No modification needed for "chat" status
+        return xml
     }
 
     logger.info("Modifying presence XML for target status: \(targetStatus)")
     
     var modifiedXml = xml
     
-    // Remove the league_of_legends element if present
     if let lolStartRange = modifiedXml.range(of: "<league_of_legends>"),
        let lolEndRange = modifiedXml.range(of: "</league_of_legends>") {
         let fullRange = lolStartRange.lowerBound..<lolEndRange.upperBound
         modifiedXml.removeSubrange(fullRange)
     }
 
-    // Remove the keystone element if present
     if let keystoneStartRange = modifiedXml.range(of: "<keystone>"),
        let keystoneEndRange = modifiedXml.range(of: "</keystone>") {
         let fullRange = keystoneStartRange.lowerBound..<keystoneEndRange.upperBound
         modifiedXml.removeSubrange(fullRange)
     }
     
-    // Remove the riot_client element if present
     if let riotClientStartRange = modifiedXml.range(of: "<riot_client>"),
        let riotClientEndRange = modifiedXml.range(of: "</riot_client>") {
         let fullRange = riotClientStartRange.lowerBound..<riotClientEndRange.upperBound
         modifiedXml.removeSubrange(fullRange)
     }
     
-    // Replace the show tag content with "offline"
     if let showStartRange = modifiedXml.range(of: "<show>"),
        let showEndRange = modifiedXml.range(of: "</show>") {
         let showContentRange = showStartRange.upperBound..<showEndRange.lowerBound
@@ -355,7 +323,6 @@ final class ClientToServerHandler: ChannelInboundHandler {
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let buffer = unwrapInboundIn(data)
         
-        // Forward client data to server (with possible modification)
         connection.processClientData(buffer).whenFailure { [weak context] error in
             logger.error("Error forwarding client data: \(error)")
             if let ctx = context {
@@ -369,15 +336,14 @@ final class ClientToServerHandler: ChannelInboundHandler {
     func errorCaught(context: ChannelHandlerContext, error: Error) {
         logger.error("Client handler error: \(error)")
         
-        // For SSL/TLS shutdown, don't treat as a fatal error
-        if let sslError = error as? NIOSSLError, 
+        if let sslError = error as? NIOSSLError,
            case .uncleanShutdown = sslError {
             return
         }
         
         context.eventLoop.execute {
-                context.close(promise: nil)
-            }
+            context.close(promise: nil)
+        }
     }
     
     func channelInactive(context: ChannelHandlerContext) {
@@ -400,7 +366,6 @@ final class ServerToClientHandler: ChannelInboundHandler {
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let buffer = unwrapInboundIn(data)
         
-        // Forward server data to client (no modification needed)
         connection.forwardToClient(buffer).whenFailure { [weak context] error in
             logger.error("Error forwarding server data: \(error)")
             if let ctx = context {
@@ -414,19 +379,18 @@ final class ServerToClientHandler: ChannelInboundHandler {
     func errorCaught(context: ChannelHandlerContext, error: Error) {
         logger.error("Server handler error: \(error)")
         
-        // For SSL/TLS shutdown, don't treat as a fatal error
-        if let sslError = error as? NIOSSLError, 
+        if let sslError = error as? NIOSSLError,
            case .uncleanShutdown = sslError {
             return
         }
         
         context.eventLoop.execute {
-                context.close(promise: nil)
-            }
+            context.close(promise: nil)
+        }
     }
     
     func channelInactive(context: ChannelHandlerContext) {
         logger.debug("Server disconnected, closing client connection")
         connection.clientChannel.close(promise: nil)
     }
-} 
+}

--- a/NoChat4U/GameClient.swift
+++ b/NoChat4U/GameClient.swift
@@ -28,7 +28,7 @@ public struct ClientStatus {
     let launchedByApp: Bool
 }
 
-public func isRiotClientRunning() -> ClientStatus {
+public func isRiotClientRunning() async -> ClientStatus {
     let process = Process()
     process.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
     process.arguments = ["-f", "RiotClientServices"]
@@ -38,13 +38,17 @@ public func isRiotClientRunning() -> ClientStatus {
     
     do {
         try process.run()
-        process.waitUntilExit()
+        
+        await withCheckedContinuation { continuation in
+            process.terminationHandler = { _ in
+                continuation.resume()
+            }
+        }
         
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         let output = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         
         let isRunning = !output.isEmpty
-        
         return ClientStatus(isRunning: isRunning, launchedByApp: clientLaunchedByApp)
     } catch {
         print("Error checking if Riot Client is running: \(error)")
@@ -65,9 +69,7 @@ public func launchLeagueClient(proxyHost: String, proxyPort: UInt16) throws {
     
     try process.run()
     
-    // Mark that we've launched the client
     clientLaunchedByApp = true
-    // Store the PID of the launched process
     launchedClientPID = process.processIdentifier
 }
 
@@ -77,7 +79,7 @@ public func resetClientLaunchedFlag() {
 }
 
 // Terminate the launched client process
-public func terminateLeagueClient() {
+public func terminateLeagueClient() async {
     if clientLaunchedByApp, let pid = launchedClientPID {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/kill")
@@ -85,7 +87,11 @@ public func terminateLeagueClient() {
 
         do {
             try process.run()
-            process.waitUntilExit()
+            await withCheckedContinuation { continuation in
+                process.terminationHandler = { _ in
+                    continuation.resume()
+                }
+            }
             print("Attempted to terminate client process with PID \(pid)")
         } catch {
             print("Error attempting to terminate client process \(pid): \(error)")
@@ -99,4 +105,4 @@ public func terminateLeagueClient() {
 
 enum LeagueClientError: Error {
     case installFileNotFound
-} 
+}

--- a/NoChat4U/Info.plist
+++ b/NoChat4U/Info.plist
@@ -7,7 +7,7 @@
 	<key>SUFeedURL</key>
 	<string>https://raw.githubusercontent.com/miguel-mpm/NoChat4U/refs/heads/main/appcast.xml</string>
 	<key>SUScheduledCheckInterval</key>
-	<string>28800</string>
+	<integer>28800</integer>
 	<key>SUShowReleaseNotes</key>
 	<false/>
 	<key>CFBundleShortVersionString</key>

--- a/NoChat4U/NoChat4UApp.swift
+++ b/NoChat4U/NoChat4UApp.swift
@@ -3,8 +3,9 @@ import AppKit
 
 public class AppDelegate: NSObject, NSApplicationDelegate {
     public func applicationWillTerminate(_ notification: Notification) {
-        // Terminate the Riot Client when the app closes
-        terminateLeagueClient()
+        Task {
+            await terminateLeagueClient()
+        }
     }
 }
 

--- a/NoChat4U/RiotClientAPI.swift
+++ b/NoChat4U/RiotClientAPI.swift
@@ -1,0 +1,165 @@
+import Foundation
+import Logging
+
+/// Calls the Riot Client local API to sync the client-side chat status
+/// with what NoChat4U shows other users, eliminating the visual mismatch
+/// where the League client still shows "Online" even though the proxy
+/// intercepts presence stanzas.
+enum RiotClientAPI {
+    private static let logger = Logger(label: "NoChat4U.RiotClientAPI")
+
+    // MARK: - Lockfile
+
+    /// Known lockfile locations, ordered by priority.
+    private static let lockfileCandidates: [String] = {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        return [
+            // Riot Client launcher (multi-game)
+            home.appendingPathComponent("Library/Application Support/Riot Games/Riot Client/Config/lockfile").path,
+            // League of Legends game client
+            "/Applications/League of Legends.app/Contents/LoL/lockfile",
+        ]
+    }()
+
+    /// Parsed lockfile content.
+    private struct Lockfile: Sendable {
+        let name: String
+        let pid: Int
+        let port: Int
+        let password: String
+        let proto: String
+
+        init?(line: String) {
+            let parts = line.split(separator: ":", omittingEmptySubsequences: false)
+            guard parts.count == 5,
+                  let pid = Int(parts[1]),
+                  let port = Int(parts[2]) else { return nil }
+            self.name = String(parts[0])
+            self.pid = pid
+            self.port = port
+            self.password = String(parts[3])
+            self.proto = String(parts[4])
+        }
+    }
+
+    // MARK: - Public API
+
+    /// Updates the availability status the League client displays to the user.
+    ///
+    /// - Parameter availability: One of `"chat"`, `"offline"`, `"away"`, `"dnd"`.
+    ///   Currently only `"chat"` and `"offline"` are used by NoChat4U.
+    static func updateAvailability(_ availability: String) {
+        guard let lockfile = findLockfile() else {
+            logger.debug("No Riot Client lockfile found; skipping client-side status sync")
+            return
+        }
+        logger.info(
+            "Syncing client-side status",
+            metadata: ["availability": .string(availability), "port": .string("\(lockfile.port)")]
+        )
+
+        Task {
+            await putAvailability(availability, lockfile: lockfile, attempt: 1)
+        }
+    }
+
+    /// Best-effort call with retry. Fires a Task so callers never block.
+    static func updateAvailability(_ availability: String, afterDelay seconds: Double) {
+        Task {
+            try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            guard let lockfile = findLockfile() else {
+                logger.debug("No lockfile after delay; giving up")
+                return
+            }
+            await putAvailability(availability, lockfile: lockfile, attempt: 1)
+        }
+    }
+
+    // MARK: - Internal
+
+    private static func findLockfile() -> Lockfile? {
+        for path in lockfileCandidates {
+            guard let content = try? String(contentsOfFile: path, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+                  !content.isEmpty else { continue }
+
+            if let lockfile = Lockfile(line: content) {
+                logger.debug("Found lockfile at \(path) — port \(lockfile.port)")
+                return lockfile
+            }
+        }
+        return nil
+    }
+
+    private static func putAvailability(
+        _ availability: String,
+        lockfile: Lockfile,
+        attempt: Int
+    ) async {
+        let maxAttempts = 5
+        guard attempt <= maxAttempts else {
+            logger.warning("Giving up after \(maxAttempts) attempts")
+            return
+        }
+
+        let url = URL(string: "https://127.0.0.1:\(lockfile.port)/chat/v3/me")!
+
+        var request = URLRequest(url: url, timeoutInterval: 10)
+        request.httpMethod = "PUT"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        // Auth: Basic base64("riot:password")
+        let authString = "riot:\(lockfile.password)"
+        let authData = Data(authString.utf8).base64EncodedString()
+        request.setValue("Basic \(authData)", forHTTPHeaderField: "Authorization")
+
+        let body = ["availability": availability]
+        request.httpBody = try? JSONEncoder().encode(body)
+
+        // Self-signed certificate — accept any server trust.
+        let session = URLSession(
+            configuration: .ephemeral,
+            delegate: AcceptAllCertsDelegate(),
+            delegateQueue: nil
+        )
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            let httpResponse = response as? HTTPURLResponse
+            logger.info(
+                "PUT /chat/v3/me → \(httpResponse?.statusCode ?? 0)",
+                metadata: ["attempt": .string("\(attempt)")]
+            )
+
+            if httpResponse?.statusCode == 200 || httpResponse?.statusCode == 204 {
+                logger.info("Client-side status synced to \(availability)")
+            } else if let body = String(data: data, encoding: .utf8) {
+                logger.debug("Response body: \(body)")
+            }
+        } catch {
+            let delay = min(Double(attempt) * 2.0, 10.0)
+            logger.warning(
+                "PUT /chat/v3/me failed (attempt \(attempt)): \(error.localizedDescription). Retrying in \(delay)s"
+            )
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            await putAvailability(availability, lockfile: lockfile, attempt: attempt + 1)
+        }
+    }
+}
+
+// MARK: - URLSession delegate that accepts self-signed TLS certificates
+
+private final class AcceptAllCertsDelegate: NSObject, URLSessionDelegate, @unchecked Sendable {
+    func urlSession(
+        _ session: URLSession,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+              let trust = challenge.protectionSpace.serverTrust else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+        completionHandler(.useCredential, URLCredential(trust: trust))
+    }
+}

--- a/NoChat4U/RiotClientAPI.swift
+++ b/NoChat4U/RiotClientAPI.swift
@@ -44,34 +44,35 @@ enum RiotClientAPI {
 
     // MARK: - Public API
 
-    /// Updates the availability status the League client displays to the user.
+    /// Updates the chat state the League client displays to the user.
     ///
-    /// - Parameter availability: One of `"chat"`, `"offline"`, `"away"`, `"dnd"`.
+    /// - Parameter state: One of the `ChatAccountState` enum values.
     ///   Currently only `"chat"` and `"offline"` are used by NoChat4U.
-    static func updateAvailability(_ availability: String) {
+    ///   Accepts: `"chat"`, `"offline"`, `"away"`, `"mobile"`, `"dnd"`.
+    static func updateState(_ state: String) {
         guard let lockfile = findLockfile() else {
             logger.debug("No Riot Client lockfile found; skipping client-side status sync")
             return
         }
         logger.info(
-            "Syncing client-side status",
-            metadata: ["availability": .string(availability), "port": .string("\(lockfile.port)")]
+            "Syncing client-side chat state",
+            metadata: ["state": .string(state), "port": .string("\(lockfile.port)")]
         )
 
         Task {
-            await putAvailability(availability, lockfile: lockfile, attempt: 1)
+            await putState(state, lockfile: lockfile, attempt: 1)
         }
     }
 
     /// Best-effort call with retry. Fires a Task so callers never block.
-    static func updateAvailability(_ availability: String, afterDelay seconds: Double) {
+    static func updateState(_ state: String, afterDelay seconds: Double) {
         Task {
             try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
             guard let lockfile = findLockfile() else {
                 logger.debug("No lockfile after delay; giving up")
                 return
             }
-            await putAvailability(availability, lockfile: lockfile, attempt: 1)
+            await putState(state, lockfile: lockfile, attempt: 1)
         }
     }
 
@@ -91,8 +92,8 @@ enum RiotClientAPI {
         return nil
     }
 
-    private static func putAvailability(
-        _ availability: String,
+    private static func putState(
+        _ state: String,
         lockfile: Lockfile,
         attempt: Int
     ) async {
@@ -113,7 +114,9 @@ enum RiotClientAPI {
         let authData = Data(authString.utf8).base64EncodedString()
         request.setValue("Basic \(authData)", forHTTPHeaderField: "Authorization")
 
-        let body = ["availability": availability]
+        // ChatChatGamePresence schema (all fields optional).
+        // Only `state` is needed to change the chat presence dot.
+        let body: [String: String] = ["state": state]
         request.httpBody = try? JSONEncoder().encode(body)
 
         // Self-signed certificate — accept any server trust.
@@ -132,7 +135,7 @@ enum RiotClientAPI {
             )
 
             if httpResponse?.statusCode == 200 || httpResponse?.statusCode == 204 {
-                logger.info("Client-side status synced to \(availability)")
+                logger.info("Client-side chat state synced to \(state)")
             } else if let body = String(data: data, encoding: .utf8) {
                 logger.debug("Response body: \(body)")
             }
@@ -142,7 +145,7 @@ enum RiotClientAPI {
                 "PUT /chat/v3/me failed (attempt \(attempt)): \(error.localizedDescription). Retrying in \(delay)s"
             )
             try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
-            await putAvailability(availability, lockfile: lockfile, attempt: attempt + 1)
+            await putState(state, lockfile: lockfile, attempt: attempt + 1)
         }
     }
 }

--- a/NoChat4U/SharedState.swift
+++ b/NoChat4U/SharedState.swift
@@ -1,45 +1,51 @@
 import Foundation
+import os
 
-class SharedState {
+final class SharedState {
     static let shared = SharedState()
     
-    private(set) var originalChatHost: String?
-    private(set) var originalChatPort: Int?
-    private(set) var chatProxyPort: Int?
-    private(set) var lastPresenceXML: String?
+    private let lock = OSAllocatedUnfairLock()
+    
+    private var _originalChatHost: String?
+    private var _originalChatPort: Int?
+    private var _chatProxyPort: Int?
+    private var _lastPresenceXML: String?
+    
+    var originalChatHost: String? { lock.withLock { _originalChatHost } }
+    var originalChatPort: Int?    { lock.withLock { _originalChatPort } }
+    var chatProxyPort: Int?       { lock.withLock { _chatProxyPort } }
+    var lastPresenceXML: String?  { lock.withLock { _lastPresenceXML } }
     
     private init() {}
     
     func setOriginalChatServer(host: String, port: Int) {
-        self.originalChatHost = host
-        self.originalChatPort = port
+        lock.withLock {
+            _originalChatHost = host
+            _originalChatPort = port
+        }
     }
     
     func setChatProxyPort(_ port: Int) {
-        self.chatProxyPort = port
+        lock.withLock { _chatProxyPort = port }
     }
     
     var targetStatus: String {
-        get {
-            return PersistentStorage.shared.targetStatus
-        }
+        get { PersistentStorage.shared.targetStatus }
         set {
-            guard newValue == "chat" || newValue == "offline" else {
-                return
-            }
+            guard newValue == "chat" || newValue == "offline" else { return }
             PersistentStorage.shared.targetStatus = newValue
         }
     }
     
     func setTargetStatus(_ status: String) {
-        self.targetStatus = status
+        targetStatus = status
     }
     
     func storeLastPresence(_ xml: String) {
-        self.lastPresenceXML = xml
+        lock.withLock { _lastPresenceXML = xml }
     }
     
     func getLastPresence() -> String? {
-        return lastPresenceXML
+        lock.withLock { _lastPresenceXML }
     }
-} 
+}

--- a/NoChat4U/StatusManager.swift
+++ b/NoChat4U/StatusManager.swift
@@ -10,11 +10,9 @@ class StatusManager: ObservableObject {
     var port: Int = 0
     @Published var isOffline: Bool = false {
         didSet {
-            // Update SharedState when isOffline changes
             SharedState.shared.setTargetStatus(isOffline ? "offline" : "chat")
             logger.info("Status changed", metadata: ["status": .string(isOffline ? "offline" : "chat")])
             
-            // Post notification to trigger presence update
             NotificationCenter.default.post(name: Notification.Name("StatusChanged"), object: nil)
         }
     }
@@ -27,25 +25,24 @@ class StatusManager: ObservableObject {
     private var clientCheckTimer: Timer?
     private var app: Application?
     
-    // Public accessor for the Vapor app for feedback functionality
     var vaporApp: Application? {
         return app
     }
         
     init() {
-        // Load persisted status
         let persistedStatus = SharedState.shared.targetStatus
         isOffline = persistedStatus == "offline"
         logger.info("Loaded persisted status", metadata: ["status": .string(persistedStatus)])
         
-        Task {
+        Task { [weak self] in
+            guard let self = self else { return }
             var env = try Environment.detect()
             try LoggingSystem.bootstrap(from: &env)
 
             let vaporApp = try await Application.make(env)
             self.app = vaporApp
 
-            vaporApp.http.server.configuration.port = 0 // Random port
+            vaporApp.http.server.configuration.port = 0
             vaporApp.http.server.configuration.hostname = "127.0.0.1"
             vaporApp.http.server.configuration.backlog = 8
             vaporApp.http.server.configuration.reuseAddress = true
@@ -54,12 +51,11 @@ class StatusManager: ObservableObject {
                 try await route(vaporApp)
                 try await vaporApp.startup()
 
-                // Fetch the TLS certificate for the MITM proxy
                 let (chain, key) = try await CertificateManager.fetchCertificate()
 
-                // Start chat proxy
-                chatProxy = try ChatProxy(certificateChain: chain, privateKey: key)
-                try chatProxy?.start()
+                let proxy = try ChatProxy(certificateChain: chain, privateKey: key)
+                self.chatProxy = proxy
+                try proxy.start()
             } catch {
                 vaporApp.logger.report(error: error)
                 try? await vaporApp.asyncShutdown()
@@ -71,10 +67,8 @@ class StatusManager: ObservableObject {
                 alert.runModal()
             }
 
-            port = vaporApp.http.server.shared.localAddress?.port ?? 0
-            
-            // Start checking for Riot client
-            startClientMonitoring()
+            self.port = vaporApp.http.server.shared.localAddress?.port ?? 0
+            self.startClientMonitoring()
         }
     }
     
@@ -87,12 +81,10 @@ class StatusManager: ObservableObject {
     }
     
     func startClientMonitoring() {
-        // Check initially
         Task { @MainActor in
             await checkClientStatus()
         }
         
-        // Check every 2 seconds
         clientCheckTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
             Task { @MainActor [weak self] in
                 await self?.checkClientStatus()
@@ -101,9 +93,8 @@ class StatusManager: ObservableObject {
     }
     
     private func checkClientStatus() async {
-        let status = isRiotClientRunning()
+        let status = await isRiotClientRunning()
         
-        // If client was running and is now not running, reset the launchedByApp flag
         if isClientRunning && !status.isRunning {
             resetClientLaunchedFlag()
         }
@@ -113,9 +104,9 @@ class StatusManager: ObservableObject {
             isClientLaunchedByApp = status.launchedByApp
             
             logger.info(
-                "Riot client status changed", 
+                "Riot client status changed",
                 metadata: [
-                    "running": .string(status.isRunning ? "yes" : "no"), 
+                    "running": .string(status.isRunning ? "yes" : "no"),
                     "launchedByApp": .string(status.launchedByApp ? "yes" : "no")
                 ]
             )
@@ -127,9 +118,7 @@ class StatusManager: ObservableObject {
             let configPort = port
             try launchLeagueClient(proxyHost: "127.0.0.1", proxyPort: UInt16(configPort))
             
-            // Immediately check client status after launch attempt
             Task { @MainActor in
-                // Give it a moment to start
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
                 await checkClientStatus()
             }
@@ -137,4 +126,4 @@ class StatusManager: ObservableObject {
             self.logger.error("Failed to launch League client: \(error)")
         }
     }
-} 
+}

--- a/NoChat4U/StatusManager.swift
+++ b/NoChat4U/StatusManager.swift
@@ -10,15 +10,15 @@ class StatusManager: ObservableObject {
     var port: Int = 0
     @Published var isOffline: Bool = false {
         didSet {
-            let availability = isOffline ? "offline" : "chat"
-            SharedState.shared.setTargetStatus(availability)
-            logger.info("Status changed", metadata: ["status": .string(availability)])
+            let state = isOffline ? "offline" : "chat"
+            SharedState.shared.setTargetStatus(state)
+            logger.info("Status changed", metadata: ["status": .string(state)])
             
             NotificationCenter.default.post(name: Notification.Name("StatusChanged"), object: nil)
             
             // Sync the visual status in the League client UI so it matches
             // what other users see via the proxy (issue #3).
-            RiotClientAPI.updateAvailability(availability)
+            RiotClientAPI.updateState(state)
         }
     }
     
@@ -114,7 +114,7 @@ class StatusManager: ObservableObject {
             // offline, re-sync the client-side status so it does not show
             // "Online" after startup. Delay to let the local API initialize.
             if !wasRunning && status.isRunning && isOffline {
-                RiotClientAPI.updateAvailability("offline", afterDelay: 4.0)
+                RiotClientAPI.updateState("offline", afterDelay: 4.0)
             }
             
             logger.info(

--- a/NoChat4U/StatusManager.swift
+++ b/NoChat4U/StatusManager.swift
@@ -10,10 +10,15 @@ class StatusManager: ObservableObject {
     var port: Int = 0
     @Published var isOffline: Bool = false {
         didSet {
-            SharedState.shared.setTargetStatus(isOffline ? "offline" : "chat")
-            logger.info("Status changed", metadata: ["status": .string(isOffline ? "offline" : "chat")])
+            let availability = isOffline ? "offline" : "chat"
+            SharedState.shared.setTargetStatus(availability)
+            logger.info("Status changed", metadata: ["status": .string(availability)])
             
             NotificationCenter.default.post(name: Notification.Name("StatusChanged"), object: nil)
+            
+            // Sync the visual status in the League client UI so it matches
+            // what other users see via the proxy (issue #3).
+            RiotClientAPI.updateAvailability(availability)
         }
     }
     
@@ -99,9 +104,18 @@ class StatusManager: ObservableObject {
             resetClientLaunchedFlag()
         }
         
+        let wasRunning = isClientRunning
+        
         if status.isRunning != isClientRunning || status.launchedByApp != isClientLaunchedByApp {
             isClientRunning = status.isRunning
             isClientLaunchedByApp = status.launchedByApp
+            
+            // When the Riot Client comes online while NoChat4U is set to
+            // offline, re-sync the client-side status so it does not show
+            // "Online" after startup. Delay to let the local API initialize.
+            if !wasRunning && status.isRunning && isOffline {
+                RiotClientAPI.updateAvailability("offline", afterDelay: 4.0)
+            }
             
             logger.info(
                 "Riot client status changed",


### PR DESCRIPTION
## Summary

Fixes #3 — eliminates the visual mismatch where the League client still shows "Online" (green dot) even though NoChat4U intercepts presence stanzas to show the user as offline to other players.

## How it works

When the user toggles their status in NoChat4U:
1. The proxy continues to intercept presence stanzas (existing behavior)
2. **New:** NoChat4U also calls the Riot Client local API (`PUT /chat/v3/me`) to update the client's own status display

The status sync happens in two scenarios:
- **On toggle:** immediate best-effort call (fire-and-forget, non-blocking)
- **On client startup:** if NoChat4U is set to offline when the Riot Client starts, the sync is re-triggered after a 4-second delay to let the local API initialize

## Schema verification

The `state` field was reverse-engineered from the Riot Client OpenAPI spec found in [`Julianw03/RCLS`](https://github.com/Julianw03/RCLS/blob/master/rcls-backend/src/main/resources/swagger/riot-client-openapi.json):

```
ChatAccountState = "offline" | "mobile" | "away" | "chat" | "dnd"

ChatChatGamePresence {
  state: ChatAccountState     // all fields optional
  shared: { product, ... }
  msg, packedData, parties, private, privateJwt, sharedJwt
}

PUT /chat/v3/me → body: ChatChatGamePresence
```

### Body sent

```json
{"state": "offline"}     // when toggling offline
{"state": "chat"}        // when toggling online
```

## Implementation

- **`RiotClientAPI.swift`** — new file that discovers the Riot Client lockfile, extracts the local API port and auth token, and calls `PUT /chat/v3/me` with Basic auth
- **`StatusManager.swift`** — modified `isOffline` didSet to call `RiotClientAPI.updateState()` and `checkClientStatus()` to sync on client startup
- Uses `URLSession` with a custom delegate that accepts self-signed TLS certificates (required for the Riot Client local API)
- Retries up to 5 times with exponential backoff (2-10s) when the local API is temporarily unavailable

## Review notes

- No blocking calls on MainActor — all API calls are fire-and-forget via `Task`
- Lockfile is read fresh on each call (no caching; the file is local and tiny)
- Silently no-ops when the lockfile isn't found (client not running)
- No new dependencies — uses Foundation `URLSession` and the existing `Logging` framework (already a transitive dep of Vapor/NIO)
- New file is auto-discovered by Xcode (project uses `PBXFileSystemSynchronizedRootGroup`)